### PR TITLE
Add `evaluator plot` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ include = [
     "LICENSE",   # Include the LICENSE file
     "README.md", # Include README or other files
     "src/evaluator/config.toml",
+    "src/evaluator/commands/plot/r/**",
     "docs/*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ include = [
 
 [dependency-groups]
 dev = [
+    "openpyxl>=3.1.5",
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
 ]

--- a/src/evaluator/cli.py
+++ b/src/evaluator/cli.py
@@ -55,7 +55,7 @@ evaluator.add_typer(
 evaluator.add_typer(
     evaluatorAnalyse,
 )
-evaluator.add_type(
+evaluator.add_typer(
     evaluatorPlot,
 )
 evaluator.add_typer(

--- a/src/evaluator/cli.py
+++ b/src/evaluator/cli.py
@@ -24,6 +24,7 @@ from evaluator.commands.analyse.cli import evaluatorAnalyse
 from evaluator.commands.label.cli import evaluatorLabel
 from evaluator.commands.license.cli import evaluatorLicense
 from evaluator.commands.model.cli import evaluatorModel
+from evaluator.commands.plot.cli import evaluatorPlot
 from evaluator.commands.version.cli import evaluatorVersion
 from evaluator.commands.visualise.cli import evaluatorVisualise
 
@@ -53,6 +54,9 @@ evaluator.add_typer(
 )
 evaluator.add_typer(
     evaluatorAnalyse,
+)
+evaluator.add_type(
+    evaluatorPlot,
 )
 evaluator.add_typer(
     evaluatorVisualise,

--- a/src/evaluator/commands/plot/cli.py
+++ b/src/evaluator/commands/plot/cli.py
@@ -1,0 +1,72 @@
+'''
+=======================================
+EValuator: ANALYSE/MODEL RESULTS PLOTTING
+=======================================
+'''
+
+# ====================
+# Import external dependencies
+# ====================
+import typer
+from pathlib import Path
+from typing import Annotated, Optional
+
+# ====================
+# Import EValuator utilities
+# ====================
+from evaluator.commands.plot import plot as plotFuncs
+
+# ====================
+# Initialise typer as evaluatorPlot
+# ====================
+evaluatorPlot = typer.Typer(
+    add_completion=False,
+)
+
+VALID_SECTIONS = ["distributions", "qc", "scatter", "concordance", "compare"]
+
+@evaluatorPlot.command(help='Generate plots from evaluator analyse and/or model output', rich_help_panel='Component Analysis')
+def plot(
+    analyse_input: Annotated[
+        Optional[Path],
+        typer.Option('--analyse', help='Path to an analyse results CSV, or a sample sheet referencing multiple', exists=True, file_okay=True, dir_okay=False, readable=True)
+    ] = None,
+    model_input: Annotated[
+        Optional[Path],
+        typer.Option('--model', help='Path to a model results file (JSON or CSV), or a sample sheet referencing multiple', exists=True, file_okay=True, dir_okay=False, readable=True)
+    ] = None,
+    output: Annotated[
+        Path,
+        typer.Option('-o', '--out-dir', help='Path to output directory, outputs written under ".../evaluator/plot/"', file_okay=False, dir_okay=True, writable=True)
+    ] = Path('.'),
+    section: Annotated[
+        Optional[list[str]],
+        typer.Option('--section', help=f"Section(s) to run: {', '.join(VALID_SECTIONS)} (repeatable)")
+    ] = None,
+    all_sections: Annotated[
+        bool,
+        typer.Option('--all', help='Run every applicable section')
+    ] = False,
+    overwrite: Annotated[
+        bool,
+        typer.Option('--overwrite', help='Overwrite existing section outputs instead of skipping them')
+    ] = False,
+    rscript: Annotated[
+        Optional[Path],
+        typer.Option('--rscript', help='Path to the Rscript binary (default: resolved from PATH)')
+    ] = None,
+):
+    '''
+    Generate plots and summary tables from `analyse` and/or `model` output.
+    '''
+    if analyse_input is None and model_input is None:
+        raise typer.BadParameter('At least one of --analyse or --model must be provided.')
+    plotFuncs.run_plot(
+        analyse_input,
+        model_input,
+        output,
+        sections=section,
+        all_sections=all_sections,
+        overwrite=overwrite,
+        rscript=rscript,
+    )

--- a/src/evaluator/commands/plot/plot.py
+++ b/src/evaluator/commands/plot/plot.py
@@ -1,0 +1,91 @@
+'''
+=======================================
+EValuator: EV MORPHOLOGY FEATURES PLOTTING
+=======================================
+'''
+
+# ====================
+# Import external dependencies
+# ====================
+from pathlib import Path
+
+# ====================
+# Import EValuator utilities
+# ====================
+from evaluator.utils import config as confutil
+from evaluator.utils import paths as pathutil
+from evaluator.utils.settings import lg
+from evaluator.commands.plot.utils.input import resolve_plot_inputs, available_sections, PlotRun
+from evaluator.commands.plot.utils.dispatch import resolve_rscript, dispatch, RscriptError
+
+# ====================
+# Define R scripts for each section
+# ====================
+SECTION_SCRIPTS = {
+    'distributions': 'distributions.R',
+    'qc': 'qc.R',
+    'scatter': 'scatter.R',
+    'concordance': 'concordance.R',
+    'compare': 'compare.R',
+}
+
+# ====================
+# run_plot: orchestration logic for plot command
+# ====================
+def run_plot(analyse_input, model_input, output, sections, all_sections, overwrite, rscript):
+    config, evaluator_dir = confutil.load_config(output)
+    params = config.plot
+    runs, multi_run, sheet_path = resolve_plot_inputs(analyse_input, model_input)
+    runnable = available_sections(runs, multi_run)
+    requested = runnable if all_sections else (sections or params.default_sections)
+    to_run = [s for s in requested if s in runnable]
+    skipped = set(requested) - set(to_run)
+    if skipped:
+        lg.warning(f'plot | Section(s) not runnable with the given input and will be skipped: {sorted(skipped)}')
+    if not to_run:
+        lg.error('plot | No runnable sections for the given input.')
+        return
+    rscript_bin = resolve_rscript(rscript)
+    out_dir = pathutil.generate_command_output_dir(evaluator_dir, 'plot')
+    confutil.write_params(params, out_dir)
+    completed = []
+    for section in to_run:
+        section_dir = out_dir / section
+        if section_dir.exists() and not overwrite:
+            lg.warning(f'plot | {section_dir} already exists, skipping (use --overwrite to replace).')
+            continue
+        section_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            _run_section(section, runs, multi_run, section_dir, rscript_bin, params, sheet_path)
+            completed.append(section)
+        except RscriptError as e:
+            lg.warning(f'plot | Section {section} failed: {e}')
+    _write_index(out_dir, completed)
+    lg.info(f'plot | Finished. Sections completed: {completed}')
+
+# ====================
+# _run_section: orchestration logic for each section
+# ====================
+def _run_section(section: str, runs, multi_run: bool, section_dir: Path, rscript_bin: Path, params, sheet_path: Path | None = None) -> None:
+    mode = 'multi' if multi_run else 'single'
+    script = SECTION_SCRIPTS[section]
+    if section == 'concordance':
+        run = runs[0]
+        dispatch(rscript_bin, script, [section_dir, run.analyse_path, run.model_path, mode])
+    elif section == 'qc':
+        run = runs[0]
+        dispatch(rscript_bin, script, [section_dir, run.analyse_path, mode, params.fill_ratio_flag_threshold])
+    elif section in ('distributions', 'scatter'):
+        run = runs[0]
+        dispatch(rscript_bin, script, [section_dir, run.analyse_path, mode])
+    elif section == 'compare':
+        dispatch(rscript_bin, script, [section_dir, sheet_path, mode])
+
+# ====================
+# _write_index: write the markdown index of all generated files
+# ====================
+def _write_index(out_dir: Path, sections: list[str]) -> None:
+    lines = ['# EValuator plot results', '']
+    for s in sections:
+        lines.append(f'- [`{s}/`]({s}/)')
+    (out_dir / 'index.md').write_text('\n'.join(lines) + '\n')

--- a/src/evaluator/commands/plot/r/compare.R
+++ b/src/evaluator/commands/plot/r/compare.R
@@ -1,0 +1,55 @@
+# compare.R: plot group comparisons
+
+# Parse positional arguments
+args <- commandArgs(trailingOnly = TRUE)
+output_dir <- args[1]; sheet_path <- args[2]; mode <- args[3]
+
+# Get script directory for path traversal
+script_dir <- local({
+  args <- commandArgs(trailingOnly = FALSE)
+  script <- grep("^--file=", args, value = TRUE)
+  dirname(normalizePath(sub("^--file=", "", script)))
+})
+
+# Import internal utilities
+source(file.path(script_dir, "utils", "import.R"))
+source(file.path(script_dir, "utils", "io.R"))
+source(file.path(script_dir, "utils", "theme.R"))
+
+# Load data sheets
+sheet <- readr::read_tsv(sheet_path, show_col_types = FALSE)
+loaded <- lapply(seq_len(nrow(sheet)), function(i) {
+  row <- sheet[i, ]
+  df <- loadAnalyseCSV(row$path)
+  df$sample_id <- row$sample_id
+  df$group <- row$group
+  df
+})
+combined <- dplyr::bind_rows(loaded)
+
+# Define features to plot and plot violin plot for each group
+features <- c("equiv_diameter_nm", "aspect_ratio", "closure_fill_ratio", "lumen_volume")
+pal <- groupPalette(combined$group)
+for (feat in intersect(features, names(combined))) {
+  p <- ggplot2::ggplot(combined, ggplot2::aes(x = group, y = .data[[feat]], fill = group)) +
+    ggplot2::geom_violin(alpha = 0.6) + ggplot2::geom_boxplot(width = 0.1, outlier.shape = NA) +
+    ggplot2::scale_fill_manual(values = pal) + evTheme() + ggplot2::theme(legend.position = "none")
+  saveSVG(p, file.path(output_dir, paste0("violin_", feat, ".svg")))
+}
+
+# Create matrix for features and save PCA plot
+feature_matrix <- combined[, intersect(features, names(combined))]
+feature_matrix <- feature_matrix[stats::complete.cases(feature_matrix), ]
+if (nrow(feature_matrix) >= 3 && ncol(feature_matrix) >= 2) {
+  pca <- stats::prcomp(scale(feature_matrix))
+  pca_df <- data.frame(pca$x[, 1:2], group = combined$group[stats::complete.cases(combined[, features])])
+  p_pca <- ggplot2::ggplot(pca_df, ggplot2::aes(x = PC1, y = PC2, colour = group)) +
+    ggplot2::geom_point(alpha = 0.7) + ggplot2::scale_colour_manual(values = pal) + evTheme()
+  saveSVG(p_pca, file.path(output_dir, "pca.svg"), width = 6, height = 6)
+}
+
+# Write results to spreadsheet
+writeXLSX(dplyr::summarise(dplyr::group_by(combined, group),
+  n_evs = dplyr::n(),
+  across(all_of(intersect(features, names(combined))), list(mean = ~mean(.x, na.rm=TRUE), median = ~median(.x, na.rm=TRUE)))),
+  file.path(output_dir, "group_summary.xlsx"))

--- a/src/evaluator/commands/plot/r/concordance.R
+++ b/src/evaluator/commands/plot/r/concordance.R
@@ -1,0 +1,58 @@
+# concordance.R: plot concordance between model and analyse
+
+# Parse positional arguments
+args <- commandArgs(trailingOnly = TRUE)
+output_dir <- args[1]; analyse_path <- args[2]; model_path <- args[3]; mode <- args[4]
+
+# Get script directory for path traversal
+script_dir <- local({
+  args <- commandArgs(trailingOnly = FALSE)
+  script <- grep("^--file=", args, value = TRUE)
+  dirname(normalizePath(sub("^--file=", "", script)))
+})
+
+# Import internal utilities
+source(file.path(script_dir, "utils", "import.R"))
+source(file.path(script_dir, "utils", "io.R"))
+source(file.path(script_dir, "utils", "theme.R"))
+
+# Import data
+analyse_df <- loadAnalyseCSV(analyse_path)
+model_df <- loadModelResults(model_path)
+joined <- joinAnalyseModel(analyse_df, model_df)
+if (nrow(joined) == 0) {
+  stop("No matching (tomogram, label) rows between analyse and model output — check both were run on the same labelled MRC(s).")
+}
+joined$model_diameter_nm <- joined$radius * 2
+
+# Diameter concordance: model's fitted diameter vs analyse's two independent diameter estimates, with y = x reference line.
+for (analyse_diam in c("equiv_diameter_nm", "major_axis_diameter")) {
+  p <- ggplot2::ggplot(joined, ggplot2::aes(x = .data[[analyse_diam]], y = model_diameter_nm, colour = tomogram)) +
+    ggplot2::geom_point(alpha = 0.6) +
+    ggplot2::geom_abline(slope = 1, intercept = 0, linetype = "dashed", colour = "grey40") +
+    evTheme() + ggplot2::theme(legend.position = "none") +
+    ggplot2::labs(x = analyse_diam, y = "model_diameter_nm (2 x fitted radius)")
+  saveSVG(p, file.path(output_dir, paste0("model_vs_", analyse_diam, ".svg")), width = 5, height = 5)
+}
+
+# See if model reliability tracks analyse's independent closure signal
+p_reliab <- ggplot2::ggplot(joined, ggplot2::aes(x = reliability.is_reliable, y = closure_fill_ratio)) +
+  ggplot2::geom_boxplot(fill = "#56B4E9") + evTheme() +
+  ggplot2::labs(x = "model reliability.is_reliable", y = "analyse closure_fill_ratio")
+saveSVG(p_reliab, file.path(output_dir, "reliability_vs_closure.svg"))
+
+# RMSE of the fit vs whether analyse independently judged the EV enclosed
+p_rmse <- ggplot2::ggplot(joined, ggplot2::aes(x = is_enclosed, y = rmse_nm)) +
+  ggplot2::geom_boxplot(fill = "#D55E00") + evTheme() +
+  ggplot2::labs(x = "analyse is_enclosed", y = "model rmse_nm")
+saveSVG(p_rmse, file.path(output_dir, "fit_rmse_vs_enclosed.svg"))
+
+conc_stats <- data.frame(
+  n_matched = nrow(joined),
+  n_analyse_only = nrow(analyse_df) - nrow(joined),
+  n_model_only = nrow(model_df) - nrow(joined),
+  pearson_equiv = cor(joined$equiv_diameter_nm, joined$model_diameter_nm, use = "complete.obs"),
+  pearson_major = cor(joined$major_axis_diameter, joined$model_diameter_nm, use = "complete.obs"),
+  reliable_pass_rate = mean(joined$reliability.is_reliable, na.rm = TRUE)
+)
+writeXLSX(conc_stats, file.path(output_dir, "concordance_stats.xlsx"))

--- a/src/evaluator/commands/plot/r/distributions.R
+++ b/src/evaluator/commands/plot/r/distributions.R
@@ -1,0 +1,40 @@
+# distributions.R: plot distribution of EV morphometrics
+
+# Parse positional arguments
+args <- commandArgs(trailingOnly = TRUE)
+output_dir <- args[1]; analyse_path <- args[2]; mode <- args[3]
+
+# Get script directory for path traversal
+script_dir <- local({
+  args <- commandArgs(trailingOnly = FALSE)
+  script <- grep("^--file=", args, value = TRUE)
+  dirname(normalizePath(sub("^--file=", "", script)))
+})
+
+# Import internal utilities
+source(file.path(script_dir, "utils", "import.R"))
+source(file.path(script_dir, "utils", "io.R"))
+source(file.path(script_dir, "utils", "theme.R"))
+
+# Import data
+df <- loadAnalyseCSV(analyse_path)
+
+# Define morphology features to plot
+features <- c("equiv_diameter_nm", "major_axis_diameter", "minor_axis_diameter", "aspect_ratio", "eccentricity", "membrane_volume", "lumen_volume", "surface_area", "closure_fill_ratio")
+
+# For each feature, create a plot and spreadsheet showing distribution
+stats <- list()
+for (feat in intersect(features, names(df))) {
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = .data[[feat]])) +
+    ggplot2::geom_density(fill = "#56B4E9", alpha = 0.4) +
+    ggplot2::geom_rug(alpha = 0.3) +
+    evTheme() + ggplot2::labs(title = feat)
+  saveSVG(p, file.path(output_dir, paste0(feat, "_density.svg")))
+  v <- df[[feat]]
+  stats[[feat]] <- data.frame(
+    feature = feat, n = sum(!is.na(v)), mean = mean(v, na.rm = TRUE),
+    median = median(v, na.rm = TRUE), sd = sd(v, na.rm = TRUE),
+    p5 = quantile(v, 0.05, na.rm = TRUE), p95 = quantile(v, 0.95, na.rm = TRUE)
+  )
+}
+writeXLSX(do.call(rbind, stats), file.path(output_dir, "summary_stats.xlsx"))

--- a/src/evaluator/commands/plot/r/qc.R
+++ b/src/evaluator/commands/plot/r/qc.R
@@ -1,0 +1,44 @@
+# qc.R: plot qc metrics
+
+# Parse positional arguments
+args <- commandArgs(trailingOnly = TRUE)
+output_dir <- args[1]; analyse_path <- args[2]; mode <- args[3]
+
+# Get script directory for path traversal
+script_dir <- local({
+  args <- commandArgs(trailingOnly = FALSE)
+  script <- grep("^--file=", args, value = TRUE)
+  dirname(normalizePath(sub("^--file=", "", script)))
+})
+
+# Import internal utilities
+source(file.path(script_dir, "utils", "import.R"))
+source(file.path(script_dir, "utils", "io.R"))
+source(file.path(script_dir, "utils", "theme.R"))
+
+# Import data
+df <- loadAnalyseCSV(analyse_path)
+
+# Calculate number of EVs per tomogram and plot
+count_per_tomo <- dplyr::count(df, tomogram, name = "n_evs")
+saveSVG(ggplot2::ggplot(count_per_tomo, ggplot2::aes(x = tomogram, y = n_evs)) +
+  ggplot2::geom_col(fill = "#0072B2") + evTheme() +
+  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1)),
+  file.path(output_dir, "count_per_tomogram.svg"))
+
+# Calculate number of enclosed EVs per tomogram and plot
+pass_rate <- dplyr::summarise(dplyr::group_by(df, tomogram),
+  pass_rate = mean(is_enclosed, na.rm = TRUE), .groups = "drop")
+saveSVG(ggplot2::ggplot(pass_rate, ggplot2::aes(x = tomogram, y = pass_rate)) +
+  ggplot2::geom_col(fill = "#009E73") + ggplot2::ylim(0, 1) + evTheme() +
+  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1)),
+  file.path(output_dir, "closure_pass_rate.svg"))
+
+saveSVG(ggplot2::ggplot(df, ggplot2::aes(x = closure_fill_ratio)) +
+  ggplot2::geom_histogram(bins = 30, fill = "#D55E00") + evTheme(),
+  file.path(output_dir, "closure_fill_ratio_distribution.svg"))
+
+writeXLSX(dplyr::summarise(dplyr::group_by(df, tomogram),
+  n_evs = dplyr::n(), pass_rate = mean(is_enclosed, na.rm = TRUE),
+  median_fill_ratio = median(closure_fill_ratio, na.rm = TRUE), .groups = "drop"),
+  file.path(output_dir, "qc_summary.xlsx"))

--- a/src/evaluator/commands/plot/r/qc.R
+++ b/src/evaluator/commands/plot/r/qc.R
@@ -2,7 +2,7 @@
 
 # Parse positional arguments
 args <- commandArgs(trailingOnly = TRUE)
-output_dir <- args[1]; analyse_path <- args[2]; mode <- args[3]
+output_dir <- args[1]; analyse_path <- args[2]; mode <- args[3]; fill_ratio_flag_threshold <- as.numeric(args[4])
 
 # Get script directory for path traversal
 script_dir <- local({
@@ -35,10 +35,13 @@ saveSVG(ggplot2::ggplot(pass_rate, ggplot2::aes(x = tomogram, y = pass_rate)) +
   file.path(output_dir, "closure_pass_rate.svg"))
 
 saveSVG(ggplot2::ggplot(df, ggplot2::aes(x = closure_fill_ratio)) +
-  ggplot2::geom_histogram(bins = 30, fill = "#D55E00") + evTheme(),
+  ggplot2::geom_histogram(bins = 30, fill = "#D55E00") + evTheme() +
+  ggplot2::geom_vline(xintercept = fill_ratio_flag_threshold, linetype = "dashed", colour = "black"),
   file.path(output_dir, "closure_fill_ratio_distribution.svg"))
 
 writeXLSX(dplyr::summarise(dplyr::group_by(df, tomogram),
   n_evs = dplyr::n(), pass_rate = mean(is_enclosed, na.rm = TRUE),
-  median_fill_ratio = median(closure_fill_ratio, na.rm = TRUE), .groups = "drop"),
+  median_fill_ratio = median(closure_fill_ratio, na.rm = TRUE),
+  n_flagged_low_fill = sum(closure_fill_ratio < fill_ratio_flag_threshold, na.rm = TRUE),
+  .groups = "drop"),
   file.path(output_dir, "qc_summary.xlsx"))

--- a/src/evaluator/commands/plot/r/scatter.R
+++ b/src/evaluator/commands/plot/r/scatter.R
@@ -1,0 +1,46 @@
+# scatter.R: plot scatter graph of morphometrics
+
+# Parse positional arguments
+args <- commandArgs(trailingOnly = TRUE)
+output_dir <- args[1]; analyse_path <- args[2]; mode <- args[3]
+
+# Get script directory for path traversal
+script_dir <- local({
+  args <- commandArgs(trailingOnly = FALSE)
+  script <- grep("^--file=", args, value = TRUE)
+  dirname(normalizePath(sub("^--file=", "", script)))
+})
+
+# Import internal utilities
+source(file.path(script_dir, "utils", "import.R"))
+source(file.path(script_dir, "utils", "io.R"))
+source(file.path(script_dir, "utils", "theme.R"))
+
+# Import data
+df <- loadAnalyseCSV(analyse_path)
+
+# Define list of pairs to analyse
+pairs <- list(
+  c("equiv_diameter_nm", "lumen_volume"),
+  c("surface_area", "lumen_volume"),
+  c("aspect_ratio", "equiv_diameter_nm")
+)
+stats_rows <- list()
+
+# For each pair, plot the scatter and write a spreadsheet with stats
+for (pair in pairs) {
+  x <- pair[1]; y <- pair[2]
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = .data[[x]], y = .data[[y]], colour = tomogram)) +
+    ggplot2::geom_point(alpha = 0.6) +
+    ggplot2::geom_smooth(method = "lm", se = FALSE, linewidth = 0.5) +
+    evTheme() + ggplot2::theme(legend.position = "none")
+  saveSVG(p, file.path(output_dir, paste0(x, "_vs_", y, ".svg")))
+  fit <- lm(df[[y]] ~ df[[x]])
+  stats_rows[[length(stats_rows) + 1]] <- data.frame(
+    x = x, y = y,
+    pearson_r = cor(df[[x]], df[[y]], use = "complete.obs"),
+    spearman_r = cor(df[[x]], df[[y]], use = "complete.obs", method = "spearman"),
+    slope = coef(fit)[2], slope_se = summary(fit)$coefficients[2, 2]
+  )
+}
+writeXLSX(do.call(rbind, stats_rows), file.path(output_dir, "scatter_stats.xlsx"))

--- a/src/evaluator/commands/plot/r/utils/import.R
+++ b/src/evaluator/commands/plot/r/utils/import.R
@@ -1,0 +1,45 @@
+# Data ingestion for plot sections
+
+loadAnalyseCSV <- function(path) {
+  df <- readr::read_csv(path, show_col_types = FALSE)
+  required <- c("tomogram", "label", "equiv_diameter_nm", "major_axis_diameter", "minor_axis_diameter", "aspect_ratio", "eccentricity", "membrane_volume", "lumen_volume", "surface_area", "is_enclosed", "closure_fill_ratio")
+  validateColumns(df, required)
+  df
+}
+
+# model output may be JSON (default) or the flattened CSV form (nested fields JSON-encoded per-cell)
+loadModelResults <- function(path) {
+  if (grepl("\\.json$", path)) {
+    payload <- jsonlite::fromJSON(path, simplifyDataFrame = TRUE, flatten = TRUE)
+    df <- payload$results
+  } else {
+    df <- readr::read_csv(path, show_col_types = FALSE)
+    for (col in intersect(c("reliability.is_reliable", "reliability"), names(df))) {
+      # nested reliability is JSON-encoded per cell in CSV mode; unpack is_reliable only
+      if (col == "reliability") {
+        parsed <- lapply(df$reliability, function(x) jsonlite::fromJSON(x))
+        df$reliability.is_reliable <- vapply(parsed, function(x) isTRUE(x$is_reliable), logical(1))
+      }
+    }
+  }
+  required <- c("label_id", "source_file", "chosen_model", "radius", "rmse_nm")
+  validateColumns(df, required)
+  df
+}
+
+validateColumns <- function(df, required) {
+  missing <- setdiff(required, names(df))
+  if (length(missing) > 0) {
+    stop(sprintf("Input missing required column(s): %s", paste(missing, collapse = ", ")))
+  }
+}
+
+# Join analyse and model rows for the same vesicle
+joinAnalyseModel <- function(analyse_df, model_df) {
+  model_df$tomogram <- basename(model_df$source_file)
+  dplyr::inner_join(
+    analyse_df, model_df,
+    by = c("tomogram" = "tomogram", "label" = "label_id"),
+    suffix = c(".analyse", ".model")
+  )
+}

--- a/src/evaluator/commands/plot/r/utils/io.R
+++ b/src/evaluator/commands/plot/r/utils/io.R
@@ -1,0 +1,11 @@
+# Shared utilities for input/output operations
+
+# Save a plot to SVG file
+saveSVG <- function(plot, path, width = 6, height = 4) {
+  ggplot2::ggsave(path, plot = plot, width = width, height = height, device = "svg")
+}
+
+# Save a dataframe to a XLSX spreadsheet
+writeXLSX <- function(df, path, sheet = "Sheet1") {
+  openxlsx::write.xlsx(df, path, sheetName = sheet, overwrite = TRUE)
+}

--- a/src/evaluator/commands/plot/r/utils/io.R
+++ b/src/evaluator/commands/plot/r/utils/io.R
@@ -8,4 +8,33 @@ saveSVG <- function(plot, path, width = 6, height = 4) {
 # Save a dataframe to a XLSX spreadsheet
 writeXLSX <- function(df, path, sheet = "Sheet1") {
   openxlsx::write.xlsx(df, path, sheetName = sheet, overwrite = TRUE)
+  stripDanglingDrawingRefs(path)
+}
+
+# stripDanglingDrawingRefs: fix a bug in openxlsx (>= 4.2.8) where worksheet entries aren't included in zip file causing issue with some readers
+stripDanglingDrawingRefs <- function(path) {
+  tmp <- tempfile()
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  zip::unzip(path, exdir = tmp)
+
+  relsPath <- file.path(tmp, "xl", "worksheets", "_rels", "sheet1.xml.rels")
+  if (file.exists(relsPath)) {
+    s <- readLines(relsPath, warn = FALSE)
+    s <- gsub('<Relationship[^>]*Type="[^"]*(drawing|vmlDrawing)[^"]*"[^>]*/>', "", s)
+    writeLines(s, relsPath)
+  }
+
+  ctPath <- file.path(tmp, "[Content_Types].xml")
+  if (file.exists(ctPath)) {
+    s <- readLines(ctPath, warn = FALSE)
+    s <- gsub('<Override[^>]*PartName="/xl/drawings/drawing1.xml"[^>]*/>', "", s)
+    writeLines(s, ctPath)
+  }
+
+  files <- list.files(tmp, recursive = TRUE, all.files = TRUE)
+  unlink(path)
+  old <- setwd(tmp)
+  on.exit(setwd(old), add = TRUE)
+  zip::zip(path, files)
 }

--- a/src/evaluator/commands/plot/r/utils/theme.R
+++ b/src/evaluator/commands/plot/r/utils/theme.R
@@ -1,0 +1,17 @@
+# Shared theme for plotting
+
+evTheme <- function() {
+  ggplot2::theme_minimal(base_size = 11) +
+    ggplot2::theme(
+      panel.grid.minor = ggplot2::element_blank(),
+      legend.position = "right",
+      plot.title = ggplot2::element_text(face = "bold")
+    )
+}
+
+# Okabe-Ito for <=8 groups (colour-blind safe), Viridis beyond.
+groupPalette <- function(groups) {
+  okabe_ito <- c("#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7", "#000000")
+  n <- length(unique(groups))
+  if (n <= length(okabe_ito)) okabe_ito[seq_len(n)] else viridisLite::viridis(n)
+}

--- a/src/evaluator/commands/plot/utils/dispatch.py
+++ b/src/evaluator/commands/plot/utils/dispatch.py
@@ -1,0 +1,57 @@
+'''
+=======================================
+EValuator: PLOT COMMAND R SCRIPT DISPATCH
+=======================================
+'''
+
+# ====================
+# Import external dependencies
+# ====================
+import shutil, subprocess
+from importlib.resources import files as pkg_files
+from pathlib import Path
+
+# ====================
+# Import internal EValuator dependencies
+# ====================
+from evaluator.utils.settings import lg
+
+# ====================
+# Define custom error classes
+# ====================
+class RscriptNotFoundError(RuntimeError):
+    '''Raised when no usable Rscript binary can be resolved'''
+
+class RscriptError(RuntimeError):
+    '''Raised when an R script exits non-zero'''
+
+# ====================
+# Define Rscript dispatch functions
+# ====================
+def resolve_rscript(rscript: Path | None) -> Path:
+    if rscript is not None:
+        if not rscript.exists():
+            raise RscriptNotFoundError(f'Rscript not found at {rscript}')
+        return rscript
+    found = shutil.which("Rscript")
+    if found is None:
+        raise RscriptNotFoundError('Rscript not found on PATH. Install R to PATH, or pass --rscript.')
+    return Path(found)
+
+def _script_path(name: str) -> Path:
+    return Path(str(pkg_files('evaluator.commands.plot') / 'r' / name))
+
+def dispatch(rscript_bin: Path, script_name: str, args: list[str]) -> None:
+    '''
+    Run r/<script_name> with positional args, streaming stderr as it's produced
+    '''
+    script = _script_path(script_name)
+    cmd = [str(rscript_bin), str(script), *[str(a) for a in args]]
+    lg.debug(f"plot | Running: {' '.join(cmd)}")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.stdout:
+        lg.debug(f"plot | {script_name} stdout:\n{proc.stdout}")
+    if proc.returncode != 0:
+        raise RscriptError(f"{script_name} failed (exit {proc.returncode}):\n{proc.stderr}")
+    if proc.stderr:
+        lg.debug(f"plot | {script_name} stderr:\n{proc.stderr}")

--- a/src/evaluator/commands/plot/utils/input.py
+++ b/src/evaluator/commands/plot/utils/input.py
@@ -1,0 +1,92 @@
+'''
+=======================================
+EValuator: PLOT COMMAND INPUT RESOLUTION
+=======================================
+'''
+
+# ====================
+# Import external dependencies
+# ====================
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+# ====================
+# Import internal EValuator utilities
+# ====================
+from evaluator.utils.settings import lg
+
+# ====================
+# Define constant variables
+# ====================
+# Required column in sheet for plotting
+REQUIRED_SHEET_COLUMNS = {'sample_id'}
+
+# ====================
+# Define dataclass for a run of Plot
+# ====================
+@dataclass(frozen=True)
+class PlotRun:
+    sample_id: str
+    analyse_path: Path | None
+    model_path: Path | None
+    group: str | None = None
+    replicate: int | None = None
+
+# ====================
+# Define functions for parsing plot input
+# ====================
+def _is_sample_sheet(path: Path) -> bool:
+    '''A sample sheet is a TSV with a header row containing sample_id'''
+    if path.suffix.lower() not in {".tsv", ".txt"}:
+        return False
+    with path.open(newline="") as fh:
+        header = fh.readline().strip().split("\t")
+    return "sample_id" in header
+
+def resolve_plot_inputs(analyse_input: Path | None, model_input: Path | None) -> tuple[list[PlotRun], bool]:
+    '''
+    Resolve --analyse/--model into a list of PlotRun entries and whether this is multi-run mode (sample sheet supplied on either side)
+    '''
+    analyse_sheet = analyse_input is not None and _is_sample_sheet(analyse_input)
+    model_sheet = model_input is not None and _is_sample_sheet(model_input)
+    if not analyse_sheet and not model_sheet:
+        run = PlotRun(sample_id="sample", analyse_path=analyse_input, model_path=model_input)
+        return [run], False
+    analyse_rows = _read_sheet(analyse_input) if analyse_sheet else {}
+    model_rows = _read_sheet(model_input) if model_sheet else {}
+    sample_ids = set(analyse_rows) | set(model_rows)
+    runs = []
+    for sid in sorted(sample_ids):
+        a_row = analyse_rows.get(sid, {})
+        m_row = model_rows.get(sid, {})
+        runs.append(PlotRun(
+            sample_id=sid,
+            analyse_path=Path(a_row["path"]).expanduser() if a_row.get("path") else (analyse_input if not analyse_sheet else None),
+            model_path=Path(m_row["path"]).expanduser() if m_row.get("path") else (model_input if not model_sheet else None),
+            group=a_row.get("group") or m_row.get("group"),
+            replicate=int(a_row["replicate"]) if a_row.get("replicate") else (int(m_row["replicate"]) if m_row.get("replicate") else None),
+        ))
+    return runs, True
+
+def _read_sheet(path: Path) -> dict[str, dict]:
+    with path.open(newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        if not REQUIRED_SHEET_COLUMNS.issubset(reader.fieldnames or []):
+            raise ValueError(f'{path.name}: sample sheet missing required column(s) {REQUIRED_SHEET_COLUMNS}')
+        rows = {row["sample_id"]: row for row in reader}
+    lg.debug(f'plot | Loaded {len(rows)} row(s) from sample sheet {path.name}')
+    return rows
+
+def available_sections(runs: list[PlotRun], multi_run: bool) -> list[str]:
+    '''Determine which sections are runnable given what input was actually supplied'''
+    has_analyse = any(r.analyse_path for r in runs)
+    has_model = any(r.model_path for r in runs)
+    sections = []
+    if has_analyse:
+        sections += ['distributions', 'qc', 'scatter']
+    if has_analyse and has_model:
+        sections.append("concordance")
+    if multi_run and len({r.group for r in runs if r.group} ) > 1:
+        sections.append('compare')
+    return sections

--- a/src/evaluator/commands/plot/utils/input.py
+++ b/src/evaluator/commands/plot/utils/input.py
@@ -44,15 +44,16 @@ def _is_sample_sheet(path: Path) -> bool:
         header = fh.readline().strip().split("\t")
     return "sample_id" in header
 
-def resolve_plot_inputs(analyse_input: Path | None, model_input: Path | None) -> tuple[list[PlotRun], bool]:
+def resolve_plot_inputs(analyse_input: Path | None, model_input: Path | None) -> tuple[list[PlotRun], bool, Path | None]:
     '''
-    Resolve --analyse/--model into a list of PlotRun entries and whether this is multi-run mode (sample sheet supplied on either side)
+    Resolve --analyse/--model into a list of PlotRun entries, whether this is multi-run mode (sample sheet supplied on either side), and the sheet path used (if any)
     '''
     analyse_sheet = analyse_input is not None and _is_sample_sheet(analyse_input)
     model_sheet = model_input is not None and _is_sample_sheet(model_input)
     if not analyse_sheet and not model_sheet:
         run = PlotRun(sample_id="sample", analyse_path=analyse_input, model_path=model_input)
-        return [run], False
+        return [run], False, None
+    sheet_path = analyse_input if analyse_sheet else model_input
     analyse_rows = _read_sheet(analyse_input) if analyse_sheet else {}
     model_rows = _read_sheet(model_input) if model_sheet else {}
     sample_ids = set(analyse_rows) | set(model_rows)
@@ -67,7 +68,7 @@ def resolve_plot_inputs(analyse_input: Path | None, model_input: Path | None) ->
             group=a_row.get("group") or m_row.get("group"),
             replicate=int(a_row["replicate"]) if a_row.get("replicate") else (int(m_row["replicate"]) if m_row.get("replicate") else None),
         ))
-    return runs, True
+    return runs, True, sheet_path
 
 def _read_sheet(path: Path) -> dict[str, dict]:
     with path.open(newline="") as fh:

--- a/src/evaluator/commands/plot/utils/input.py
+++ b/src/evaluator/commands/plot/utils/input.py
@@ -37,12 +37,8 @@ class PlotRun:
 # Define functions for parsing plot input
 # ====================
 def _is_sample_sheet(path: Path) -> bool:
-    '''A sample sheet is a TSV with a header row containing sample_id'''
-    if path.suffix.lower() not in {".tsv", ".txt"}:
-        return False
-    with path.open(newline="") as fh:
-        header = fh.readline().strip().split("\t")
-    return "sample_id" in header
+    '''A sample sheet is any TSV/TXT file (headers validated on read)'''
+    return path.suffix.lower() in {".tsv", ".txt"}
 
 def resolve_plot_inputs(analyse_input: Path | None, model_input: Path | None) -> tuple[list[PlotRun], bool, Path | None]:
     '''

--- a/src/evaluator/config.toml
+++ b/src/evaluator/config.toml
@@ -25,6 +25,11 @@ minimum_diameter_nm = 20.0
 membrane_thickness_nm = 7
 max_workers = 0
 
+# Plot command default configuration parameters
+[plot]
+default_sections = ["distributions", "qc", "scatter"]
+fill_ratio_flag_threshold = 0.05
+
 # Visualise command default configuration parameters
 [visualise]
 overlay_style = "both"          # style of overlay to use (valid options: both, filled, contours)

--- a/src/evaluator/utils/config.py
+++ b/src/evaluator/utils/config.py
@@ -51,6 +51,12 @@ class AnalyseConfig(_Section):
     membrane_thickness_nm: float = Field(..., description='Membrane thickness (nm)')
     max_workers: int | None = Field(None, description='Maximum parallel worker processes for batch input (default: CPU count)')
 
+class PlotConfig(_Section):
+    '''Configuration parameters for `evaluator plot` command'''
+    default_sections: list[Literal['distributions', 'qc', 'scatter', 'concordance', 'compare']] = Field(
+        default_factory=lambda: ['distributions', 'qc', 'scatter'], description='Sections run when --section/--all are not given',
+    )
+    fill_ratio_flag_threshold: float = Field(0.05, description='closure_fill_ratio below this is flagged in qc plots')
 
 class VisualiseConfig(_Section):
     '''Configuration parameters for `evaluator visualise` command'''
@@ -73,6 +79,7 @@ class Config(_Section):
     label: LabelConfig
     model: ModelConfig = ModelConfig()
     analyse: AnalyseConfig
+    plot: PlotConfig = PlotConfig()
     visualise: VisualiseConfig
 
 

--- a/tests/cli/cli_test.py
+++ b/tests/cli/cli_test.py
@@ -107,6 +107,33 @@ class TestAnalyseCLI:
         )
         assert result.exit_code != 0
 
+class TestPlotCLI:
+    '''Plot command CLI tests'''
+    def test_help_exits_zero(self):
+        result = runner.invoke(evaluator, ['plot', '--help'])
+        assert result.exit_code == 0
+    def test_no_input_exits_nonzero(self):
+        result = runner.invoke(evaluator, ['plot'])
+        assert result.exit_code != 0
+    def test_nonexistent_analyse_file_exits_nonzero(self, tmp_path):
+        fake = tmp_path / 'does_not_exist.csv'
+        result = runner.invoke(evaluator, ['plot', '--analyse', str(fake)])
+        assert result.exit_code != 0
+    def test_nonexistent_model_file_exits_nonzero(self, tmp_path):
+        fake = tmp_path / 'does_not_exist.json'
+        result = runner.invoke(evaluator, ['plot', '--model', str(fake)])
+        assert result.exit_code != 0
+    def test_valid_analyse_only_dispatches(self, tmp_path):
+        analyse = tmp_path / 'analyse.csv'
+        analyse.write_text(
+            'tomogram,label,equiv_diameter_nm,major_axis_diameter,minor_axis_diameter,'
+            'aspect_ratio,eccentricity,membrane_volume,lumen_volume,surface_area,'
+            'is_enclosed,closure_fill_ratio\ntomo1.mrc,1,80.0,90.0,70.0,1.28,0.5,50000,30000,20000,True,0.4\n'
+        )
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch'):
+            result = runner.invoke(evaluator, ['plot', '--analyse', str(analyse), '-o', str(tmp_path), '--section', 'qc'])
+        assert result.exit_code == 0
 
 class TestVisualiseCLI:
     '''Visualise command CLI tests'''

--- a/tests/integration/plot_integration_test.py
+++ b/tests/integration/plot_integration_test.py
@@ -1,0 +1,98 @@
+# ====================
+# Import external dependencies
+# ====================
+import csv, pytest, shutil
+from openpyxl import load_workbook
+
+# ====================
+# Import internal dependencies
+# ====================
+from evaluator.commands.plot.plot import run_plot
+
+pytestmark = pytest.mark.skipif(
+    shutil.which('Rscript') is None,
+    reason='Rscript not on PATH',
+)
+
+# ====================
+# Define constants
+# ====================
+ANALYSE_COLUMNS = [
+    'tomogram', 'label', 'equiv_diameter_nm', 'major_axis_diameter', 'minor_axis_diameter',
+    'aspect_ratio', 'eccentricity', 'membrane_volume', 'lumen_volume', 'surface_area',
+    'is_enclosed', 'closure_fill_ratio',
+]
+
+# ====================
+# Define helper functions
+# ====================
+def _write_analyse_csv(path, n=12):
+    with path.open('w', newline='') as fh:
+        writer = csv.writer(fh)
+        writer.writerow(ANALYSE_COLUMNS)
+        for i in range(n):
+            writer.writerow([
+                'tomo1.mrc', i, 60.0 + i, 70.0 + i, 50.0 + i, 1.2, 0.4,
+                40000 + i * 100, 25000 + i * 50, 18000 + i * 80,
+                bool(i % 3), 0.02 + 0.01 * i,
+            ])
+
+# ====================
+# Define module fixtures
+# ====================
+@pytest.fixture(scope='module')
+def analyse_csv(tmp_path_factory):
+    path = tmp_path_factory.mktemp('plot_data') / 'analyse.csv'
+    _write_analyse_csv(path)
+    return path
+
+@pytest.fixture(scope='module')
+def plot_output(analyse_csv, tmp_path_factory):
+    out = tmp_path_factory.mktemp('plot_output')
+    run_plot(
+        analyse_csv, None, out,
+        sections=['distributions', 'qc'], all_sections=False,
+        overwrite=False, rscript=None,
+    )
+    return out / 'evaluator' / 'plot'
+
+# ====================
+# Define tests
+# ====================
+class TestPlotDistributionsQC:
+    def test_distributions_summary_stats_written(self, plot_output):
+        path = plot_output / 'distributions' / 'summary_stats.xlsx'
+        assert path.exists()
+        wb = load_workbook(path)
+        assert wb.active.max_row > 1  # header + at least one feature row
+
+    def test_qc_summary_written(self, plot_output):
+        path = plot_output / 'qc' / 'qc_summary.xlsx'
+        assert path.exists()
+        wb = load_workbook(path)
+        row = list(wb.active.iter_rows(min_row=2, max_row=2, values_only=True))[0]
+        assert row[0] == 'tomo1.mrc'  # tomogram column
+
+    def test_density_svg_written_per_feature(self, plot_output):
+        assert (plot_output / 'distributions' / 'equiv_diameter_nm_density.svg').exists()
+
+    def test_index_md_lists_both_sections(self, plot_output):
+        index = (plot_output / 'index.md').read_text()
+        assert 'distributions/' in index and 'qc/' in index
+
+class TestPlotConcordance:
+    def test_concordance_requires_matching_rows(self, tmp_path, analyse_csv):
+        model_json = tmp_path / 'model.json'
+        model_json.write_text(
+            "{'results': [{'label_id': 999, 'source_file': 'no_such_tomo.mrc', "
+            "'chosen_model': 'sphere', 'radius': 40.0, 'rmse_nm': 1.0, "
+            "'reliability': {'is_reliable': true}}]}"
+        )
+        out = tmp_path / 'out'
+        run_plot(
+            analyse_csv, model_json, out,
+            sections=['concordance'], all_sections=False,
+            overwrite=False, rscript=None,
+        )
+        section_dir = out / 'evaluator' / 'plot' / 'concordance'
+        assert not (section_dir / 'concordance_stats.xlsx').exists()

--- a/tests/unit/config_unit_test.py
+++ b/tests/unit/config_unit_test.py
@@ -19,6 +19,7 @@ from evaluator.utils.config import (
     ConfigNotFoundError,
     create_default_config,
     AnalyseConfig,
+    PlotConfig,
     load_config,
     read_config,
     resolve_config,
@@ -460,3 +461,26 @@ class TestEditConfigStepwise:
             with pytest.raises(Exception):
                 edit_config(cfg, stepwise=True)
         assert not candidate.exists()
+
+class TestPlotConfig:
+    def test_default_construction(self):
+        cfg = PlotConfig()
+        assert cfg.default_sections == ['distributions', 'qc', 'scatter']
+        assert cfg.fill_ratio_flag_threshold == 0.05
+
+    def test_extra_key_forbidden(self):
+        with pytest.raises(ValidationError):
+            PlotConfig(unknown_key=True)
+
+    def test_invalid_section_name_rejected(self):
+        with pytest.raises(ValidationError):
+            PlotConfig(default_sections=['not_a_real_section'])
+
+    def test_packaged_config_toml_has_plot_section(self):
+        '''config.toml's [plot] section round-trips through Config.model_validate'''
+        from importlib.resources import files
+        import tomllib
+        data = tomllib.loads((files('evaluator') / 'config.toml').read_text(encoding='utf-8'))
+        config = Config.model_validate(data)
+        assert config.plot.default_sections == ['distributions', 'qc', 'scatter']
+    

--- a/tests/unit/plot_unit_test.py
+++ b/tests/unit/plot_unit_test.py
@@ -1,0 +1,279 @@
+'''
+Unit tests for `evaluator plot`
+'''
+
+# ====================
+# Import external dependencies
+# ====================
+import pytest, subprocess, tomllib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ====================
+# Import evaluator plot functions
+# ====================
+from evaluator.commands.plot.plot import run_plot
+from evaluator.commands.plot.utils.dispatch import (
+    resolve_rscript,
+    dispatch,
+    RscriptNotFoundError,
+    RscriptError,
+)
+from evaluator.commands.plot.utils.input import (
+    PlotRun,
+    resolve_plot_inputs,
+    available_sections,
+)
+
+# ====================
+# Define helpers
+# ====================
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8')
+    return path
+
+def _sheet(path: Path, rows: list[dict]) -> Path:
+    header = ['sample_id', 'path', 'group', 'replicate']
+    lines = ['\t'.join(header)]
+    for row in rows:
+        lines.append('\t'.join(str(row.get(col, '')) for col in header))
+    return _write(path, '\n'.join(lines) + '\n')
+
+def _make_analyse_csv(tmp_path):
+    path = tmp_path / 'analyse.csv'
+    path.write_text(
+        'tomogram,label,equiv_diameter_nm,major_axis_diameter,minor_axis_diameter,'
+        'aspect_ratio,eccentricity,membrane_volume,lumen_volume,surface_area,'
+        'is_enclosed,closure_fill_ratio\n'
+        'tomo1.mrc,1,80.0,90.0,70.0,1.28,0.5,50000,30000,20000,True,0.4\n'
+    )
+    return path
+
+# ====================
+# Define tests for plot/utils/input.py
+# ====================
+class TestPlotUtilsInput:
+    # == Define tests for resolve_plot_inputs with single file (no sample sheet) ==
+    def test_analyse_only(self, tmp_path):
+        analyse = _write(tmp_path / 'analyse.csv', 'tomogram,label\n')
+        runs, multi_run, sheet_path = resolve_plot_inputs(analyse, None)
+        assert multi_run is False
+        assert sheet_path is None
+        assert runs == [PlotRun(sample_id='sample', analyse_path=analyse, model_path=None)]
+
+    def test_model_only(self, tmp_path):
+        model = _write(tmp_path / 'model.json', '{}')
+        runs, multi_run, sheet_path = resolve_plot_inputs(None, model)
+        assert multi_run is False
+        assert runs == [PlotRun(sample_id='sample', analyse_path=None, model_path=model)]
+
+    def test_both_present(self, tmp_path):
+        analyse = _write(tmp_path / 'analyse.csv', 'tomogram,label\n')
+        model = _write(tmp_path / 'model.json', '{}')
+        runs, multi_run, sheet_path = resolve_plot_inputs(analyse, model)
+        assert multi_run is False
+        assert runs == [PlotRun(sample_id='sample', analyse_path=analyse, model_path=model)]
+
+    def test_csv_suffix_never_treated_as_sheet(self, tmp_path):
+        '''A .csv with a sample_id-like header must not be sniffed as a sheet (only .tsv/.txt are)'''
+        analyse = _write(tmp_path / 'analyse.csv', 'sample_id\tpath\n')
+        runs, multi_run, sheet_path = resolve_plot_inputs(analyse, None)
+        assert multi_run is False
+
+    # == Define tests for resolve_plot_inputs with a sample sheet (from analyse or model) ==
+    def test_analyse_sheet_only(self, tmp_path):
+        a1 = _write(tmp_path / 'a1.csv', 'tomogram,label\n')
+        a2 = _write(tmp_path / 'a2.csv', 'tomogram,label\n')
+        sheet = _sheet(tmp_path / 'sheet.tsv', [
+            {'sample_id': 's1', 'path': a1, 'group': 'control'},
+            {'sample_id': 's2', 'path': a2, 'group': 'treated'},
+        ])
+        runs, multi_run, sheet_path = resolve_plot_inputs(sheet, None)
+        assert multi_run is True
+        assert sheet_path == sheet
+        assert {r.sample_id for r in runs} == {'s1', 's2'}
+        assert {r.group for r in runs} == {'control', 'treated'}
+
+    def test_model_sheet_only(self, tmp_path):
+        m1 = _write(tmp_path / 'm1.json', '{}')
+        sheet = _sheet(tmp_path / 'sheet.tsv', [{'sample_id': 's1', 'path': m1, 'group': 'g'}])
+        runs, multi_run, sheet_path = resolve_plot_inputs(None, sheet)
+        assert multi_run is True
+        assert runs[0].model_path == m1
+        assert runs[0].analyse_path is None
+
+    def test_both_sheets_joined_on_sample_id(self, tmp_path):
+        a1 = _write(tmp_path / 'a1.csv', 'tomogram,label\n')
+        m1 = _write(tmp_path / 'm1.json', '{}')
+        analyse_sheet = _sheet(tmp_path / 'analyse_sheet.tsv', [{'sample_id': 's1', 'path': a1, 'group': 'g'}])
+        model_sheet = _sheet(tmp_path / 'model_sheet.tsv', [{'sample_id': 's1', 'path': m1, 'group': 'g'}])
+        runs, multi_run, sheet_path = resolve_plot_inputs(analyse_sheet, model_sheet)
+        assert multi_run is True
+        # analyse sheet is preferred as the returned sheet_path when both sides are sheets
+        assert sheet_path == analyse_sheet
+        assert len(runs) == 1
+        assert runs[0].analyse_path == a1
+        assert runs[0].model_path == m1
+
+    def test_replicate_parsed_as_int(self, tmp_path):
+        a1 = _write(tmp_path / 'a1.csv', 'tomogram,label\n')
+        sheet = _sheet(tmp_path / 'sheet.tsv', [{'sample_id': 's1', 'path': a1, 'group': 'g', 'replicate': 2}])
+        runs, _, _ = resolve_plot_inputs(sheet, None)
+        assert runs[0].replicate == 2
+
+    def test_missing_sample_id_column_raises(self, tmp_path):
+        bad = _write(tmp_path / 'sheet.tsv', 'path\tgroup\n/x.csv\tg\n')
+        with pytest.raises(ValueError):
+            resolve_plot_inputs(bad, None)
+
+    # == Define tests for available_sections ==
+    def test_analyse_only_gives_core_sections(self):
+        runs = [PlotRun(sample_id='s', analyse_path=Path('a.csv'), model_path=None)]
+        assert available_sections(runs, False) == ['distributions', 'qc', 'scatter']
+
+    def test_model_only_gives_no_sections(self):
+        '''No section currently runs on model output alone'''
+        runs = [PlotRun(sample_id='s', analyse_path=None, model_path=Path('m.json'))]
+        assert available_sections(runs, False) == []
+
+    def test_analyse_and_model_adds_concordance(self):
+        runs = [PlotRun(sample_id='s', analyse_path=Path('a.csv'), model_path=Path('m.json'))]
+        sections = available_sections(runs, False)
+        assert 'concordance' in sections
+
+    def test_single_group_excludes_compare(self):
+        runs = [
+            PlotRun(sample_id='s1', analyse_path=Path('a1.csv'), model_path=None, group='g'),
+            PlotRun(sample_id='s2', analyse_path=Path('a2.csv'), model_path=None, group='g'),
+        ]
+        assert 'compare' not in available_sections(runs, True)
+
+    def test_multiple_groups_adds_compare(self):
+        runs = [
+            PlotRun(sample_id='s1', analyse_path=Path('a1.csv'), model_path=None, group='control'),
+            PlotRun(sample_id='s2', analyse_path=Path('a2.csv'), model_path=None, group='treated'),
+        ]
+        assert 'compare' in available_sections(runs, True)
+
+    def test_single_run_mode_never_adds_compare(self):
+        '''compare requires multi_run even if (somehow) groups differ'''
+        runs = [PlotRun(sample_id='s', analyse_path=Path('a.csv'), model_path=None, group='g')]
+        assert 'compare' not in available_sections(runs, False)
+    
+# ====================
+# Define tests for plot/utils/dispatch.py
+# ====================
+class TestPlotUtilsDispatch:
+    # == Define tests for resolve_rscript ==
+    def test_explicit_path_that_exists(self, tmp_path):
+        fake_bin = tmp_path / 'Rscript'
+        fake_bin.touch()
+        assert resolve_rscript(fake_bin) == fake_bin
+
+    def test_explicit_path_missing_raises(self, tmp_path):
+        missing = tmp_path / 'does_not_exist'
+        with pytest.raises(RscriptNotFoundError):
+            resolve_rscript(missing)
+
+    def test_falls_back_to_path_lookup(self, monkeypatch):
+        monkeypatch.setattr('shutil.which', lambda name: '/usr/bin/Rscript')
+        assert resolve_rscript(None) == Path('/usr/bin/Rscript')
+
+    def test_not_on_path_raises(self, monkeypatch):
+        monkeypatch.setattr('shutil.which', lambda name: None)
+        with pytest.raises(RscriptNotFoundError):
+            resolve_rscript(None)
+
+    # == Define tests for dispatch ==
+    def test_builds_expected_command(self):
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+            dispatch(Path('/usr/bin/Rscript'), 'qc.R', ['/out', '/analyse.csv', 'single', 0.05])
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == '/usr/bin/Rscript'
+        assert cmd[1].endswith('r/qc.R')
+        assert cmd[2:] == ['/out', '/analyse.csv', 'single', '0.05']
+
+    def test_nonzero_exit_raises_rscript_error_with_stderr(self):
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='boom')
+            with pytest.raises(RscriptError, match='boom'):
+                dispatch(Path('/usr/bin/Rscript'), 'qc.R', [])
+
+    def test_zero_exit_does_not_raise(self):
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+            dispatch(Path('/usr/bin/Rscript'), 'qc.R', [])
+
+# ====================
+# Define tests for plot/plot.py
+# ====================
+class TestPlot:
+    # == Define tests for run_plot section gating ==
+    def test_requested_but_unrunnable_section_is_skipped(self, tmp_path):
+        '''--section concordance with only --analyse given is not runnable and should be skipped'''
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch') as mock_dispatch:
+            run_plot(analyse, None, tmp_path, sections=['concordance'], all_sections=False, overwrite=False, rscript=None)
+        mock_dispatch.assert_not_called()
+
+    def test_all_sections_runs_every_runnable_section(self, tmp_path):
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch') as mock_dispatch:
+            run_plot(analyse, None, tmp_path, sections=None, all_sections=True, overwrite=False, rscript=None)
+        called_scripts = {call.args[1] for call in mock_dispatch.call_args_list}
+        assert called_scripts == {'distributions.R', 'qc.R', 'scatter.R'}
+
+    def test_qc_passes_fill_ratio_threshold_as_fourth_arg(self, tmp_path):
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch') as mock_dispatch:
+            run_plot(analyse, None, tmp_path, sections=['qc'], all_sections=False, overwrite=False, rscript=None)
+        args = mock_dispatch.call_args.args[2]
+        assert args[3] == 0.05  # PlotConfig default fill_ratio_flag_threshold
+
+    def test_section_failure_is_not_fatal(self, tmp_path):
+        '''One section raising RscriptError must not prevent other sections from running'''
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch', side_effect=RscriptError('boom')):
+            run_plot(analyse, None, tmp_path, sections=['distributions', 'qc'], all_sections=False, overwrite=False, rscript=None)  # must not raise
+
+    # == Define tests for --overwrite option ==
+    def test_existing_section_dir_skipped_without_overwrite(self, tmp_path):
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch') as mock_dispatch:
+            run_plot(analyse, None, tmp_path, sections=['qc'], all_sections=False, overwrite=False, rscript=None)
+            mock_dispatch.reset_mock()
+            run_plot(analyse, None, tmp_path, sections=['qc'], all_sections=False, overwrite=False, rscript=None)
+        mock_dispatch.assert_not_called()
+
+    def test_overwrite_reruns_existing_section(self, tmp_path):
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch') as mock_dispatch:
+            run_plot(analyse, None, tmp_path, sections=['qc'], all_sections=False, overwrite=False, rscript=None)
+            mock_dispatch.reset_mock()
+            run_plot(analyse, None, tmp_path, sections=['qc'], all_sections=False, overwrite=True, rscript=None)
+        mock_dispatch.assert_called_once()
+
+    # == Define tests for _write_index ==
+    def test_index_md_lists_completed_sections(self, tmp_path):
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch'):
+            run_plot(analyse, None, tmp_path, sections=['qc'], all_sections=False, overwrite=False, rscript=None)
+        index = (tmp_path / 'evaluator' / 'plot' / 'index.md').read_text()
+        assert 'qc/' in index
+
+    def test_params_toml_written(self, tmp_path):
+        analyse = _make_analyse_csv(tmp_path)
+        with patch('evaluator.commands.plot.plot.resolve_rscript', return_value='Rscript'), \
+             patch('evaluator.commands.plot.plot.dispatch'):
+            run_plot(analyse, None, tmp_path, sections=['qc'], all_sections=False, overwrite=False, rscript=None)
+        params = tomllib.loads((tmp_path / 'evaluator' / 'plot' / 'params.toml').read_text())
+        assert params['fill_ratio_flag_threshold'] == 0.05

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "evaluator"
 version = "0.7.7"
 source = { editable = "." }
@@ -165,6 +174,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "openpyxl" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -191,6 +201,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
 ]
@@ -394,6 +405,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
     { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Pull request (PR) description
This PR implements the `evaluator plot` command, which accepts inputs from `analyse` and/or `model` and produces summary plots and spreadsheets from these. It updates the EValuator test suite to add new unit & integration tests covering this command's functions.

## Issues resolved
n/a